### PR TITLE
Workaround for `IndexError: list index out of range`

### DIFF
--- a/medium_to_ghost/medium_post_parser.py
+++ b/medium_to_ghost/medium_post_parser.py
@@ -457,7 +457,7 @@ class MediumHTMLParser(HTMLParser):
 
         # If this text is part of an image caption, slap that caption on the last Image card so the caption
         # ends up in the right place and bail out.
-        if "figcaption" in self.tag_stack:
+        if "figcaption" in self.tag_stack and len(self.cards):
             self.cards[-1][1]["caption"] = data
             return
 


### PR DESCRIPTION
Fixes #10. In my case, I believe the figcaption belonged to an embedded tweet, which caused the script to bail out (as there was no card in the stack yet). This makes sure that the script doesn't fail in these cases.